### PR TITLE
Update AccountController.cs

### DIFF
--- a/alquimia.Api/Controllers/AccountController.cs
+++ b/alquimia.Api/Controllers/AccountController.cs
@@ -260,6 +260,24 @@ namespace alquimia.Api.Controllers
         }
     }
 
+
+
+
+  [HttpGet("perfil")]
+  [Authorize]
+  public async Task<IActionResult> ObtenerPerfil()
+  {
+      var userEmail = User.FindFirstValue(ClaimTypes.Email);
+      var user = await _userManager.FindByEmailAsync(userEmail);
+      var roles = await _userManager.GetRolesAsync(user);
+      return Ok(new
+      {
+          email = user.Email,
+          rol = roles.FirstOrDefault()
+      });
+  }
+
+
     
 
     }


### PR DESCRIPTION
Agregue un mini endpoint mas para solucionar el problema de celeste ayer, ahora en el front durante el logueo se puede saber que rol tiene el usuario, esta info la necesitan las chicas de front para poder reedirigir al usuario , si es proveedor tienen que reedirigir al home proveedor, si es creador al home creador 
![image](https://github.com/user-attachments/assets/64c3dea5-4b6d-4365-a475-f8d1d980bb42)
