### PR TITLE
Actualización de .gitignore y main.py en FastAPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ alquimia.Data/bin/*
 alquimia.Data/obj/*
 alquimia.Services/bin/*
 alquimia.Services/bin/*
-
+.env
 alquimia.Tests/obj/*
 alquimia.Tests/bin/*
 /.idea/workspace.xml

--- a/alquimia.Api/Fastapi-accords/main.py
+++ b/alquimia.Api/Fastapi-accords/main.py
@@ -3,6 +3,9 @@ from fastapi.middleware.cors import CORSMiddleware
 import requests
 from bs4 import BeautifulSoup
 import pandas as pd
+from dotenv import load_dotenv
+if os.getenv("ENVIRONMENT") != "production":
+    load_dotenv()
 
 app = FastAPI()
 
@@ -143,7 +146,9 @@ def search_perfume(name: str = Query(..., alias="q")):
 
 
     
-ZENROWS_API_KEY = "34f48787a0e21abd82d019522938fcb88289c84c"
+ZENROWS_API_KEY = os.getenv("ZENROWS_API_KEY")
+if not ZENROWS_API_KEY:
+    raise ValueError("ZENROWS_API_KEY is not set in environment variables")
 
 @app.get("/api/perfume-image")
 def get_perfume_image(url: str = Query(...)):


### PR DESCRIPTION
**### AGREGUE UN .ENV QUE ES SOLO NECESARIO EN LOCAL , YA LO DEPLOYE Y ESTA SIN ROMPER, SOLO SE QUEDO SIN TOKENS SUPONGO Y POR ESO NO DEVUELVE EL PERFUME**

![image](https://github.com/user-attachments/assets/b0573f2e-7088-4c89-ba1e-4debca352b69)


/////////////////////////////////////////////////////////////////////////////


### **ESTO ES LO QUE CONTIENE EL .ENV QUE ESTA AL LADO DEL MAIN.PY**

![image](https://github.com/user-attachments/assets/deb8bf87-887a-4c12-8f32-68fe88a157c6)


/////////////////////////////////////////////////////////////////////////////////////7

### **ESTA CARGADO EL SECRETO EN GITHUB ,SE VE EN LA FOTO ABAJO DE TODO**

![image](https://github.com/user-attachments/assets/7f3b5d43-0130-4f82-92df-c28476887db8)


///////////////////////////////////////////////////////////////////////////////////////



### **BORRE LAS CREDENCIALES DEL DB CONTEXT, QUEDO ASI:**

![image](https://github.com/user-attachments/assets/6a0befeb-61ea-4d5f-afb4-1fd084c3f64b)


////////////////////////////////////////////////////////////////////////////////////////



### **MODIFIQUE EL .GITIGNORE PARA QUE IGNORE EL .ENV QUE VA AL LADO DE MAIN.PY , EL .ENV SOLO ES NECESARIO EN LOCAL, Y NO SE SUBE, FUNCIONA IGUAL QUE NUESTRO APPSETTINGS:**

![image](https://github.com/user-attachments/assets/2938dd05-2a59-49e4-b877-4707517e45ab)


